### PR TITLE
fix: rename function manageAccountAcess to manageAccountAccess

### DIFF
--- a/frontend/src/components/navbar/navbar.tsx
+++ b/frontend/src/components/navbar/navbar.tsx
@@ -1,6 +1,6 @@
 import { useAppDispatch } from '@/redux/hooks'
 import styles from './navbar.module.scss'
-import { manageAccountAcess, openModal } from '@/redux/accountAccess/slice'
+import { manageAccountAccess, openModal } from '@/redux/accountAccess/slice'
 
 const Navbar = () => {
   const dispatch = useAppDispatch()
@@ -21,7 +21,7 @@ const Navbar = () => {
     const modal = true
 
     dispatch(openModal(modal))
-    dispatch(manageAccountAcess(hasAccount))
+    dispatch(manageAccountAccess(hasAccount))
   }
 
   if (typeof window !== 'undefined') {

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -21,7 +21,7 @@ import { IItem } from '@/interfaces/item'
 
 //Redux
 import { useAppDispatch, useAppSelector } from '@/redux/hooks'
-import { manageAccountAcess, openModal, useAccountAccess } from '@/redux/accountAccess/slice'
+import { manageAccountAccess, openModal, useAccountAccess } from '@/redux/accountAccess/slice'
 
 type TApiData = {
   pizzas: IItem[]
@@ -186,7 +186,7 @@ export default function Home({ pizzas, combos, sodas, juices, flavors, borders, 
 
   const handleAccountAccess = () => {
     const value: boolean = accountAccess.hasAccount ? false : true
-    dispatch(manageAccountAcess(value))
+    dispatch(manageAccountAccess(value))
   }
 
   if (typeof document !== 'undefined') {

--- a/frontend/src/redux/accountAccess/slice.ts
+++ b/frontend/src/redux/accountAccess/slice.ts
@@ -17,12 +17,12 @@ export const accountAccessSlice = createSlice({
     openModal: (state, action: PayloadAction<boolean>) => {
       state.modal = action.payload
     },
-    manageAccountAcess: (state, action: PayloadAction<boolean>) => {
+    manageAccountAccess: (state, action: PayloadAction<boolean>) => {
       state.hasAccount = action.payload
     },
   },
 })
 
-export const { openModal, manageAccountAcess } = accountAccessSlice.actions
+export const { openModal, manageAccountAccess } = accountAccessSlice.actions
 
 export const useAccountAccess = (state: any) => state.accountAccess as IAccountAccess


### PR DESCRIPTION
Nesse MR foi arrumado o erro de digitação na função manageAccountAccess, antes estava manageAccountAcess.